### PR TITLE
Fixes error handler route

### DIFF
--- a/templates/base/routes/error.js
+++ b/templates/base/routes/error.js
@@ -6,7 +6,7 @@ const emitter = require('monument').events
 emitter.on('error:401', (connection) => {
     const errorCode = 401;
 
-    connection.res.writeHead(errorCode, { 'Content-Type': 'text/html' });
+    connection.res.statusCode = errorCode;
     connection.res.send(errorTemplate({
         message: 'You tried to access something you aren\'t allowed to. Punk.'
         , explanation: ''
@@ -16,7 +16,7 @@ emitter.on('error:401', (connection) => {
 emitter.on('error:404', (connection) => {
     const errorCode = 404;
 
-    connection.res.writeHead(errorCode, { 'Content-Type': 'text/html' });
+    connection.res.statusCode = errorCode;
     connection.res.send(errorTemplate({
         message: 'file not found'
         , explanation: ''
@@ -26,7 +26,7 @@ emitter.on('error:404', (connection) => {
 emitter.on('error:500', (objIn) => {
     const errorCode = 500;
 
-    objIn.connection.res.writeHead(errorCode, { 'Content-Type': 'text/html' });
+    objIn.connection.res.statusCode = errorCode;
 
     if (objIn.message){
         objIn.connection.res.send(errorTemplate({

--- a/templates/data/collection.js
+++ b/templates/data/collection.js
@@ -53,7 +53,7 @@ const events = require('monument').events
                 cache.add('data.${dataName}', stubData, 300000);
             });
         } else if (cached !== null) {
-            events.emit('data:set:${dataName}', cached.find((item) => {
+            events.emit(\`data:set:${dataName}:\${id}\`, cached.find((item) => {
                 return item.id === id;
             }));
         }


### PR DESCRIPTION
These were blowing up on 404s because writeHead can't be called
after setHeader. It was also an unneeded call to set headers that
.send was setting automatically.

The other thing in here is a fix to the collection stub.