### PR TITLE
Updates the connectionStub and other things

### DIFF
--- a/modules/newProject.js
+++ b/modules/newProject.js
@@ -48,7 +48,7 @@ module.exports = (pathIn) => {
             description: 'What is the name of your project?',
             type: 'string',
             // this should change with each major release
-            default: 'la-Fleche-Wallone',
+            default: 'Coppa-Bernocchi',
             required: true
           },
           version: {

--- a/templates/base/_package.json
+++ b/templates/base/_package.json
@@ -4,7 +4,7 @@
   "description": "{{=it.description}}",
   "main": "app.js",
   "dependencies": {
-    "monument": "~3.0.4",
+    "monument": "~3.0.11",
     "node-cached": "~1.0.0",
     "dot": "~1.1.1"
   },

--- a/templates/base/test_stubs/connectionStub.js
+++ b/templates/base/test_stubs/connectionStub.js
@@ -1,8 +1,10 @@
 'use strict';
 
 let out = '',
+    forward = '',
     headers = {},
-    status = 200;
+    status = 200,
+    done;
 
 const write = (input) => {
         if (typeof input === 'object') {
@@ -10,13 +12,18 @@ const write = (input) => {
         } else {
           out = input;
         }
+
+        if (done) {
+          done();
+        }
       },
 
       show = () => {
         return {
           status: status,
           headers: headers,
-          response: out
+          response: out,
+          forward: forward
         };
       };
 
@@ -31,12 +38,27 @@ module.exports = {
     writeHead: (code, headersIn) => {
       status = code;
       headers = headersIn;
+    },
+    redirect: (url) => {
+      forward = url;
+
+      if (done) {
+        done();
+      }
     }
+  },
+  req: {
+    headers: {}
   },
   reset: () => {
     headers = {};
     status = 200;
     out = '';
+    forward = '';
+    done = null;
   },
-  out: show
+  out: show,
+  done: (cb) => {
+    done = cb;
+  }
 };

--- a/test.sh
+++ b/test.sh
@@ -3,16 +3,19 @@ npm test
 npm link
 
 #project base tests
+echo "Testing the base project scaffold"
 mkdir test-project && cd test-project
 cat ../test_stubs/project_answers | monument new .
 npm test
 
 #new route test
+echo "Testing the new route project scaffold"
 cat ../test_stubs/routes_test.json > routes.json
 monument routes
 npm test
 
 #new data test
+echo "Testing the new data project scaffold"
 cat ../test_stubs/data_obj_answers | monument data obj
 cat ../test_stubs/data_coll_answers | monument data coll
 npm test


### PR DESCRIPTION
ConnectionStub which is the backbone of route testing
was broken by the update to harken in monument 3.0.11.
This patch fixes it.

It also bumps the version of monument being used, updates
the default name to the name of the current version
name of monument, updates the test.sh file with some
logging...

and that's pretty much it